### PR TITLE
Add CSS module declaration for TypeScript 6

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';


### PR DESCRIPTION
## What
Add `global.d.ts` declaring `*.css` as an importable module.

## Why
TypeScript 6 (merged in #50) no longer accepts side-effect CSS imports without an explicit module declaration. `next build` failed on `import './globals.css'` in `app/layout.tsx`.