### PR TITLE
Document template usage, scripts, and SSG build flow in README (closes #61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,56 @@
-# Next SSG Template
+# next-ssg-template
 
-## Description
+[![License](https://img.shields.io/github/license/oota-sushikuitee/next-ssg-template)](https://github.com/oota-sushikuitee/next-ssg-template/blob/main/LICENSE)
 
-This is a simple static site generator template that uses TypeScript and Next.js.
+A minimal Next.js 15 + TypeScript + Tailwind CSS template configured for
+static site generation. `next build` emits a static `out/` directory that can
+be served by any static host (GitHub Pages, Cloudflare Pages, S3, Netlify).
+
+## Use as a template
+
+Click **Use this template** on GitHub, or:
+
+```bash
+gh repo create my-site --template oota-sushikuitee/next-ssg-template --public --clone
+```
+
+## Requirements
+
+- Node.js (see `.node-version`)
+- Yarn 4 (pinned via `packageManager` in `package.json`)
+
+Enable Corepack so the pinned Yarn version is used automatically:
+
+```bash
+corepack enable
+```
+
+## Develop
+
+```bash
+yarn install
+yarn dev        # http://localhost:3000
+```
+
+## Build
+
+```bash
+yarn build      # produces ./out
+```
+
+The output is fully static — no Node runtime is required to serve it. Upload
+the contents of `out/` to your static host of choice.
+
+## Scripts
+
+| Script          | What it does                          |
+| --------------- | ------------------------------------- |
+| `yarn dev`      | Start the dev server                  |
+| `yarn build`    | Build static export into `out/`       |
+| `yarn lint`     | Run ESLint                            |
+| `yarn lint:fix` | Run ESLint with `--fix`               |
+| `yarn format`   | Run Prettier across `app/**/*.{ts,tsx}` |
+
+## License
+
+See [LICENSE](LICENSE).


### PR DESCRIPTION
## What

Expand the README from two lines into a real template README:

- *Use as a template* section with the GitHub button and `gh repo create --template` one-liner.
- Requirements (Node from `.node-version`, Yarn 4 via `corepack enable`).
- Develop / Build sections that explain what `yarn dev` and `yarn build` produce.
- A script table covering `dev`, `build`, `lint`, `lint:fix`, `format`.
- License badge and section.

## Why

The README was a single sentence — anyone landing from *Use this template* could not tell what the entry points were, which package manager to use, or where the static output lands. A template's README is its product page.

Closes #61