### PR TITLE
Enable noUncheckedIndexedAccess and verbatimModuleSyntax

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
## What

`tsconfig.json` (+2 lines): add `noUncheckedIndexedAccess: true` and `verbatimModuleSyntax: true` inside `compilerOptions`, alongside the existing `strict: true`.

## Why

`docs/web-2026/03-javascript-and-typescript.md` lists both as baseline-strict for new TypeScript code.

- `noUncheckedIndexedAccess` returns `T | undefined` for index access, catching out-of-bounds reads at compile time
- `verbatimModuleSyntax` forces `import type` for type-only imports, eliminating phantom-runtime-module risk

As a starter template, every downstream project inherits this config — a defect here propagates indefinitely. The existing `app/` (135 lines) doesn't hit either rule, so this is zero-impact today and a permanent upgrade for every fork.

## Note

`yarn tsc --noEmit` exit 0; `yarn build` produces both `/` and `/_not-found` as static prerender. Next.js' build step still auto-injects `"target": "ES2017"` on first build — left untouched in this PR (already happens on every project install regardless of this change).

## Related

resolve: #64
