### PR TITLE
Fix Node allowedVersions regex and harden Renovate validator workflow

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,15 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>oota-sushikuitee/renovate-config"
   ],
   "packageRules": [
     {
-      "allowedVersions": "/^[0-9]+[24680]\\.[0-9]+\\.0$/",
+      "allowedVersions": "/^([0-9]*[02468])\\./",
       "groupName": "Node.js dependencies",
       "matchPackageNames": [
-        "/node/",
-        "/^@types/node$/"
+        "node",
+        "@types/node"
       ]
     },
     {

--- a/.github/workflows/renovate-validator.yml
+++ b/.github/workflows/renovate-validator.yml
@@ -6,6 +6,13 @@ on:
       - '.github/renovate.json'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -15,4 +22,4 @@ jobs:
         uses: actions/checkout@v6
 
       - name: validate renovate.json
-        run: npx --package=renovate -c renovate-config-validator
+        run: npx --package=renovate@43.250.0 -c renovate-config-validator


### PR DESCRIPTION
## What
Fix the Node `packageRule` in `.github/renovate.json` so `allowedVersions` matches any even-major Node release prefix instead of requiring an exact `x.y.0` version, and scope `matchPackageNames` to the literal `node`/`@types/node` packages instead of a `/node/` substring match. Also harden `.github/workflows/renovate-validator.yml` with explicit `permissions: contents: read`, a `concurrency` group, and a pinned `renovate` version for the validator invocation.

## Why
The previous regex `^[0-9]+[24680]\.[0-9]+\.0$` only ever matched patch version `.0`, so Renovate could never propose a Node patch bump (e.g. `24.10.1`). The `/node/` substring pattern also risked matching unrelated packages containing "node" in their name. The workflow lacked least-privilege permissions, a concurrency guard, and ran an unpinned `renovate` version, which is inconsistent with our CI hardening conventions.

## Related
(no issue — public repo, direct PR per working convention)