### PR TITLE
Stabilize sitemap output and widen format coverage

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,29 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>oota-sushikuitee/renovate-config"
-  ],
+  "extends": ["github>oota-sushikuitee/renovate-config"],
   "packageRules": [
     {
       "allowedVersions": "/^([0-9]*[02468])\\./",
       "groupName": "Node.js dependencies",
-      "matchPackageNames": [
-        "node",
-        "@types/node"
-      ]
+      "matchPackageNames": ["node", "@types/node"]
     },
     {
       "groupName": "@types dependencies",
-      "matchPackageNames": [
-        "/^@types//"
-      ]
+      "matchPackageNames": ["/^@types//"]
     },
     {
       "groupName": "linting dependencies",
-      "matchPackageNames": [
-        "/^eslint/",
-        "/^prettier/"
-      ]
+      "matchPackageNames": ["/^eslint/", "/^prettier/"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ the contents of `out/` to your static host of choice.
 
 ## Scripts
 
-| Script          | What it does                          |
-| --------------- | ------------------------------------- |
-| `yarn dev`      | Start the dev server                  |
-| `yarn build`    | Build static export into `out/`       |
-| `yarn lint`     | Run ESLint                            |
-| `yarn lint:fix` | Run ESLint with `--fix`               |
-| `yarn format`   | Run Prettier across `app/**/*.{ts,tsx}` |
+| Script          | What it does                                  |
+| --------------- | --------------------------------------------- |
+| `yarn dev`      | Start the dev server                          |
+| `yarn build`    | Build static export into `out/`               |
+| `yarn lint`     | Run ESLint                                    |
+| `yarn lint:fix` | Run ESLint with `--fix`                       |
+| `yarn format`   | Run Prettier across app and root config files |
 
 ## SEO defaults
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -6,9 +6,7 @@
  * `--background-image-*` theme namespace.
  */
 @theme {
-  --background-image-gradient-radial: radial-gradient(
-    var(--tw-gradient-stops)
-  );
+  --background-image-gradient-radial: radial-gradient(var(--tw-gradient-stops));
   --background-image-gradient-conic: conic-gradient(
     from 180deg at 50% 50%,
     var(--tw-gradient-stops)

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -6,9 +6,10 @@ export const dynamic = 'force-static';
 
 const sitemap = (): MetadataRoute.Sitemap => [
   {
-    // List every indexable page here with the date its content last changed.
+    // List every indexable page here. `lastModified` is intentionally omitted:
+    // `new Date()` would churn the sitemap on every build. Add a real date per
+    // entry (e.g. from your CMS or content frontmatter) when you have one.
     url: `${siteUrl}/`,
-    lastModified: new Date(),
   },
 ];
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "format": "prettier --write \"app/**/*.{ts,tsx}\""
+    "format": "prettier --write \"**/*.{ts,tsx,js,cjs,mjs,json,md,css}\""
   },
   "dependencies": {
     "next": "16.2.10",


### PR DESCRIPTION
## What

- Remove the `lastModified: new Date()` field from `app/sitemap.ts`. `lastModified` is optional in Next's `MetadataRoute.Sitemap`, and a build-time `new Date()` regenerated the sitemap on every build.
- Widen the `format` script glob from `app/**/*.{ts,tsx}` to `**/*.{ts,tsx,js,cjs,mjs,json,md,css}` so root-level config files (eslint.config.js, next.config.mjs, tsconfig.json, etc.) and other assets are covered by Prettier. `.prettierignore` keeps `node_modules`, `.next`, and `out` excluded.
- Apply the resulting Prettier reformat to the newly covered files (`.github/renovate.json`, `app/globals.css`, `README.md`) and update the README scripts table.

## Why

- A sitemap that changes every build produces noisy diffs and misleading `lastmod` signals for crawlers. Omitting the field yields deterministic, stable output; a real per-entry date can be added later when content actually has one.
- The previous format glob silently skipped root config files, so `yarn format` could not enforce a consistent style across the whole repo.