### PR TITLE
Correct README Next.js version claim to 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/github/license/oota-sushikuitee/next-ssg-template)](https://github.com/oota-sushikuitee/next-ssg-template/blob/main/LICENSE)
 
-A minimal Next.js 15 + TypeScript + Tailwind CSS template configured for
+A minimal Next.js 16 + TypeScript + Tailwind CSS template configured for
 static site generation. `next build` emits a static `out/` directory that can
 be served by any static host (GitHub Pages, Cloudflare Pages, S3, Netlify).
 


### PR DESCRIPTION
## What

- Update the README intro line from "Next.js 15" to "Next.js 16", matching the `next` version pinned in `package.json` (`16.2.10`).
- Scanned the rest of the README for other hardcoded framework/tooling versions (React, Tailwind CSS, Node.js); none exist — Node is referenced only via `.node-version` and Tailwind/Yarn are unversioned in prose, so no further changes were needed.

## Why

- The README described the template as Next.js 15 while `package.json` has been on Next.js 16 since #76, which is misleading for anyone using this as a starting template.