### PR TITLE
Migrate node20 actions to node24 and pin by SHA

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,4 +10,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.node-version'
 

--- a/.github/workflows/renovate-validator.yml
+++ b/.github/workflows/renovate-validator.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: validate renovate.json
         run: npx --package=renovate@43.250.0 -c renovate-config-validator


### PR DESCRIPTION
## What

Migrate GitHub Actions off the deprecated Node 20 runner runtime and SHA-pin the remaining unpinned action refs in `.github/workflows/`:

- `lint.yml`: `actions/setup-node@v4` (node20, unpinned) -> `actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0` (node24)
- `lint.yml`: `actions/checkout@v6` -> `actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3`
- `renovate-validator.yml`: `actions/checkout@v6` -> `actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3`
- `labeler.yml`: `actions/labeler@v6` -> `actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0`

The `setup-node` v4 -> v6 bump keeps the existing `node-version-file: .node-version` input, which is already used by `ci.yml` on v6.4.0, so caching/corepack behavior is unchanged.

## Why

GitHub is [deprecating the Node 20 runtime on Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/): since 2026-06-16 runners force node24 by default, and node20 is removed in Fall 2026. `actions/setup-node@v4` still runs on node20, so it is migrated to v6 (node24). Unpinned refs are pinned to full commit SHAs (with the `# vX.Y.Z` comment Renovate maintains) for supply-chain integrity.