### PR TITLE
Pin vulnerable transitive brace-expansion versions via resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
   },
   "packageManager": "yarn@4.17.1",
   "resolutions": {
-    "postcss": "^8.5.10"
+    "postcss": "^8.5.10",
+    "brace-expansion@npm:^1.1.7": "^1.1.16",
+    "brace-expansion@npm:^5.0.5": "^5.0.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1522,22 +1522,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.7":
-  version: 1.1.14
-  resolution: "brace-expansion@npm:1.1.14"
+"brace-expansion@npm:^1.1.16":
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/b6fdac832bc4e36a753658c9ed052c2e1a2be221763b002df25d1efbf7d21724334e726a6cd5eadc72a4b19ec3efb632d629cc003bc9c62f7af7a7915ffa4385
+  checksum: 10c0/3432c18a9e2ebf94162d4effb62198bd0adea06a9f332b2c0188df5d5e30b1e51ea3c848b6608e47d0b857ebe1ea5b3888ed3326dd3c4f6f9645c94153cf9c14
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.5":
-  version: 5.0.6
-  resolution: "brace-expansion@npm:5.0.6"
+"brace-expansion@npm:^5.0.7":
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Pin the two vulnerable `brace-expansion` instances to patched versions using the `resolutions` field, and regenerate `yarn.lock`.

| Advisory | Package | Vulnerable range | Patched from | Resolved to |
| --- | --- | --- | --- | --- |
| [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) | `brace-expansion` (1.x line) | `< 1.1.16` | `1.1.16` | `1.1.18` |
| [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) | `brace-expansion` (5.x line) | `>= 3.0.0, < 5.0.7` | `5.0.7` | `5.0.9` |

Both are transitive-only (development scope), reached through `minimatch@^3.1.2` (1.x line) and `minimatch@^10.2.2` (5.x line).

Because the two instances sit on incompatible major lines, an unscoped `brace-expansion` resolution would force every consumer onto a single major. The selectors are therefore scoped per descriptor so each line is lifted independently. Both patched versions already satisfy the ranges their parents declare, so no parent package needs a major bump.

The remaining open alert, `sharp` [GHSA-f88m-g3jw-g9cj](https://github.com/advisories/GHSA-f88m-g3jw-g9cj) (`< 0.35.0`), is intentionally not addressed here: #84 already moves `sharp` to `0.35.3` in the lockfile as part of the `next` 16.3.0 update, which clears the advisory.

## Why

Three high-severity Dependabot alerts are open on this repository. The `brace-expansion` ones cannot be resolved by updating a direct dependency, since nothing in `package.json` depends on it directly — the `resolutions` field is the mechanism Yarn provides for forcing a patched transitive version, matching the existing `postcss` override in this file.

## Verification

Run against the regenerated lockfile:

- `yarn install --immutable` — passes, so the committed lockfile is complete and reproducible
- `yarn lint` — clean
- `yarn tsc --noEmit` — clean
- `yarn build` — succeeds, all 6 routes prerendered as static content
