### PR TITLE
Pin nanoid and js-yaml to patched versions via resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
   "resolutions": {
     "postcss": "^8.5.10",
     "brace-expansion@npm:^1.1.7": "^1.1.16",
-    "brace-expansion@npm:^5.0.5": "^5.0.7"
+    "brace-expansion@npm:^5.0.5": "^5.0.7",
+    "nanoid@npm:^3.3.16": "^3.3.17",
+    "js-yaml@npm:^4.1.1": "^4.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2966,14 +2966,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.1":
-  version: 4.3.0
-  resolution: "js-yaml@npm:4.3.0"
+"js-yaml@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "js-yaml@npm:4.3.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
+  checksum: 10c0/13c500ca322e0c3f8c81686e6ecda96d2ea37b45247a420c17c7db36932d6965cc27391abc2d1a104501600e7f0d947a5f8b7be6db619c4fefa87901b3512807
   languageName: node
   linkType: hard
 
@@ -3295,12 +3295,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.16":
-  version: 3.3.16
-  resolution: "nanoid@npm:3.3.16"
+"nanoid@npm:^3.3.17":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/bbf2dcffe22d2b62d16de2711752070b539c0f644c7916f823ad6521986b2078cbe524f2d6240f58c46e9141ea0c7b87a029e100c0f7f175228cacaf30e41bba
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Pin `nanoid` and `js-yaml` to patched versions using the `resolutions` field, and regenerate `yarn.lock`.

| Advisory | Package | Scope | Vulnerable range | Patched from | Resolved to |
| --- | --- | --- | --- | --- | --- |
| [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) | `nanoid` | runtime | `< 3.3.17` | `3.3.17` | `3.3.18` |
| [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) | `js-yaml` | development | `>= 4.0.0, < 4.3.1` | `4.3.1` | `4.3.1` |

Both are transitive-only — `nanoid` is reached through `postcss`, and `js-yaml` through the ESLint config loader. Neither appears in `dependencies` or `devDependencies`, so there is no direct version to bump.

Both patched versions already satisfy the ranges their parents declare (`nanoid@^3.3.16`, `js-yaml@^4.1.1`), so no parent package needs a major bump. The selectors are scoped per descriptor, matching the `brace-expansion` entries added in #87.

## Why

Two high-severity Dependabot alerts surfaced on this repository after the lockfile rescan in #87. Neither can be resolved by updating a direct dependency, so `resolutions` is the mechanism Yarn provides for forcing a patched transitive version — the same approach already used here for `postcss` and `brace-expansion`.

After this lands, the only remaining open alert is `sharp` [GHSA-f88m-g3jw-g9cj](https://github.com/advisories/GHSA-f88m-g3jw-g9cj), which #84 clears by moving `sharp` to `0.35.3`.

## Verification

Run against the regenerated lockfile:

- `yarn install --immutable` — passes, so the committed lockfile is complete and reproducible
- `yarn lint` — clean
- `yarn tsc --noEmit` — clean
- `yarn build` — succeeds, all 6 routes prerendered as static content
