### PR TITLE
Normalize siteUrl before composing sitemap and robots URLs

### DIFF
--- a/app/config.ts
+++ b/app/config.ts
@@ -1,6 +1,11 @@
 // Site-wide constants used by metadata, robots.txt, and sitemap.xml.
 // Update these when creating a site from this template.
-export const siteUrl = 'https://example.com';
+const configuredSiteUrl = 'https://example.com';
 export const siteName = 'Next SSG Template';
 export const siteDescription =
   'A minimal Next.js + TypeScript + Tailwind CSS template configured for static site generation.';
+
+// Trailing slashes are stripped once here so every consumer can append a path
+// (`${siteUrl}/sitemap.xml`) without emitting a double slash, and so the URLs
+// in robots.txt and sitemap.xml match the `metadataBase` in app/layout.tsx.
+export const siteUrl = configuredSiteUrl.replace(/\/+$/, '');


### PR DESCRIPTION
## What

Normalize `siteUrl` once in `app/config.ts` by stripping trailing slashes, so
`app/sitemap.ts` and `app/robots.ts` can keep composing URLs with plain string
interpolation.

## Why

`app/config.ts` is meant to be edited when creating a site from this template,
and writing `https://example.com/` there is a natural thing to do. In that case
`metadataBase: new URL(siteUrl)` in `app/layout.tsx` normalizes the value, but
`` `${siteUrl}/` `` in the sitemap and `` `${siteUrl}/sitemap.xml` `` in
robots.txt emit double-slash URLs that disagree with the canonical metadata.

Normalizing at the single place the value is defined keeps every consumer
simple and makes all three outputs consistent regardless of how the URL is
written.

Verified with `yarn lint`, `yarn tsc --noEmit`, and `yarn build`; a temporary
build with `https://example.com//` configured produced
`Sitemap: https://example.com/sitemap.xml` and `<loc>https://example.com/</loc>`.

ref. #82
