### PR TITLE
Scope lint workflow token permissions to read-only

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,9 @@ name: ESLint
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Add a top-level `permissions: contents: read` block to
`.github/workflows/lint.yml`, matching the style already used by `ci.yml` and
`renovate-validator.yml`.

## Why

The ESLint workflow declared no `permissions`, so its `GITHUB_TOKEN` inherited
the repository default. If that default is "Read and write", a lint-only job
that runs `yarn install --immutable` and `yarn lint` would hand a write-capable
token to every dependency install and ESLint plugin it executes. The job only
needs to read the checked-out code.

ref. #82
